### PR TITLE
Update README re: experimental support for Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,9 @@ Installation
   If you are running on a clean install of Fedora 28 or above, please make sure you have the ``redhat-rpm-config`` package installed in case if you want to
   use ``sanic`` with ``ujson`` dependency.
 
+.. note::
+
+  Windows support is currently "experimental" and on a best-effort basis. Multiple workers are also not currently supported on Windows (see `Issue #1517 <https://github.com/huge-success/sanic/issues/1517>`_), but setting ``workers=1`` should launch the server successfully.
 
 Hello World Example
 -------------------


### PR DESCRIPTION
As mentioned in #1517 , Windows support is "experimental" and does not currently support multiple workers. I think it would be very useful to mention this in the main README under the installation section as supported by @sjsadowski [here](https://github.com/huge-success/sanic/issues/1545#issuecomment-479880062).